### PR TITLE
Newest version of Foundation dropdown link hover BG

### DIFF
--- a/skin/frontend/waterlee-boilerplate/default/scss/_settings.scss
+++ b/skin/frontend/waterlee-boilerplate/default/scss/_settings.scss
@@ -1170,6 +1170,7 @@ $topbar-link-bg-active-hover: #efefef;
 // $topbar-dropdown-label-font-weight: bold;
 // $topbar-dropdown-label-font-size: rem-calc(10);
 // $topbar-dropdown-label-bg: #333;
+$topbar-dropdown-link-bg-hover: $topbar-link-bg-hover;
 
 // Top menu icon styles
 // $topbar-menu-link-transform: uppercase;


### PR DESCRIPTION
Newest Foundation version specifies a different color for the dropdown link hover background. May want to update the whole _settings.scss file, but this patch at least fixes the most glaring issue.
